### PR TITLE
Fix typos and cleanup tests

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -241,9 +241,9 @@
 16. Upgrade Dubbo version to 3.2.5 and refactor some methods
 17. Refactor AbstractShenyuSdkClient getOrDefault method
 18. Refactor http client properties
-19. Refactor webcliet plugin implement
+19. Refactor webclient plugin implement
 20. Upgrade com.google.guava:guava to 32.0.0-jre
-21. support k8s as e2e test case enviroment
+21. support k8s as e2e test case environment
 22. Refactor @Restapi as rest api request mapping
 23. String concatenation recommended using StringBuilder
 24. Set the netty allocator to unpooled

--- a/shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/src/main/resources/application.yml
+++ b/shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/src/main/resources/application.yml
@@ -21,7 +21,7 @@ server:
 
 spring:
   application:
-    name: motan-exmaples
+    name: motan-examples
 
 shenyu:
   namespace: 649330b6-c2d7-4edc-be8e-8a54df9eb385

--- a/shenyu-plugin/shenyu-plugin-mock/src/test/java/org/apache/shenyu/plugin/mock/generator/RandomDoubleGeneratorTest.java
+++ b/shenyu-plugin/shenyu-plugin-mock/src/test/java/org/apache/shenyu/plugin/mock/generator/RandomDoubleGeneratorTest.java
@@ -35,10 +35,10 @@ public final class RandomDoubleGeneratorTest {
     public void generate() {
         String doubleValue = generator.generate("double|10.5-12.0", null);
         assertNotNull(doubleValue);
-        String formated = generator.generate("double|10.5-12.0|￥%.2f", null);
+        String formatted = generator.generate("double|10.5-12.0|￥%.2f", null);
         assertAll(
-            () -> assertNotNull(formated),
-            () -> assertTrue(formated.matches("^￥\\d+.\\d{2}$"))
+            () -> assertNotNull(formatted),
+            () -> assertTrue(formatted.matches("^￥\\d+.\\d{2}$"))
         );
 
     }


### PR DESCRIPTION
## Summary
- fix `motan-examples` application name
- fix spelling in release notes
- fix typo in `RandomDoubleGeneratorTest`

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479a66d3a083298b91e6d0155a1e68